### PR TITLE
add missing std includes

### DIFF
--- a/xpp_ros_conversions/include/xpp_ros_conversions/convert.h
+++ b/xpp_ros_conversions/include/xpp_ros_conversions/convert.h
@@ -27,6 +27,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef XPP_ROS_CONVERSIONS_H_
 #define XPP_ROS_CONVERSIONS_H_
 
+#include <vector>
+
 #include <xpp_msgs/StateLin3d.h>
 #include <xpp_msgs/State6d.h>
 #include <xpp_msgs/RobotStateCartesian.h>

--- a/xpp_states/include/xpp_states/endeffectors.h
+++ b/xpp_states/include/xpp_states/endeffectors.h
@@ -27,8 +27,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef _XPP_STATES_ENDEFFECTORS_H_
 #define _XPP_STATES_ENDEFFECTORS_H_
 
-#include <iostream>
 #include <deque>
+#include <iostream>
+#include <vector>
 
 #include <xpp_states/state.h>
 

--- a/xpp_vis/include/xpp_vis/cartesian_joint_converter.h
+++ b/xpp_vis/include/xpp_vis/cartesian_joint_converter.h
@@ -27,6 +27,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef XPP_VIS_CARTESIAN_JOINT_CONVERTER_H_
 #define XPP_VIS_CARTESIAN_JOINT_CONVERTER_H_
 
+#include <string>
+
 #include <ros/publisher.h>
 #include <ros/subscriber.h>
 

--- a/xpp_vis/include/xpp_vis/rviz_robot_builder.h
+++ b/xpp_vis/include/xpp_vis/rviz_robot_builder.h
@@ -27,6 +27,9 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef XPP_VIS_RVIZ_ROBOT_BUILDER_H_
 #define XPP_VIS_RVIZ_ROBOT_BUILDER_H_
 
+#include <string>
+#include <vector>
+
 #include <visualization_msgs/MarkerArray.h>
 
 #include <xpp_msgs/OptParameters.h>

--- a/xpp_vis/include/xpp_vis/rviz_terrain_builder.h
+++ b/xpp_vis/include/xpp_vis/rviz_terrain_builder.h
@@ -27,6 +27,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef XPP_RVIZ_TERRAIN_BUILDER_H_
 #define XPP_RVIZ_TERRAIN_BUILDER_H_
 
+#include <string>
+
 #include <Eigen/Dense>
 
 #include <visualization_msgs/MarkerArray.h>

--- a/xpp_vis/include/xpp_vis/urdf_visualizer.h
+++ b/xpp_vis/include/xpp_vis/urdf_visualizer.h
@@ -29,8 +29,10 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdlib>
 #include <iostream>
-#include <string>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <ros/ros.h>
 #include <tf/transform_broadcaster.h>


### PR DESCRIPTION
This should fix the currently failing [Ubuntu Zesty](http://build.ros.org/job/Lbin_uZ64__xpp_states__ubuntu_zesty_amd64__binary/1/) and [Debian Stretch](http://build.ros.org/job/Lbin_ds_dS64__xpp_states__debian_stretch_amd64__binary/1/) packaging jobs.

This will require a new release for the change to be taken into account