### PR TITLE
Removed tf_prefix from robot_state_publisher API

### DIFF
--- a/xpp_vis/src/urdf_visualizer.cc
+++ b/xpp_vis/src/urdf_visualizer.cc
@@ -70,8 +70,8 @@ UrdfVisualizer::StateCallback(const xpp_msgs::RobotStateJoint& msg)
   auto W_X_B_message   = GetBaseFromRos(::ros::Time::now(), msg.base.pose);
 
   tf_broadcaster_.sendTransform(W_X_B_message);
-  robot_publisher->publishTransforms(joint_positions, ::ros::Time::now(), tf_prefix_);
-  robot_publisher->publishFixedTransforms(tf_prefix_);
+  robot_publisher->publishTransforms(joint_positions, ::ros::Time::now());
+  robot_publisher->publishFixedTransforms();
 }
 
 UrdfVisualizer::UrdfnameToJointAngle


### PR DESCRIPTION
In ROS Melodic `robot_state_publisher` APIs will no longer have a parameter for `tf_prefix`. I'm not sure how `xpp_vis` would like to handle `tf_prefix` going forward since it is used elsewhere in `urdf_visualizer.cc`. This PR is the minimum required to get `xpp_vis` to build in a prerelease test.

Caused by ros/robot_state_publisher#82