### PR TITLE
remove tf_prefix from urdf_visualizer.h; legacy function call from tf1

### DIFF
--- a/robots/xpp_hyq/rviz/xpp_hyq.rviz
+++ b/robots/xpp_hyq/rviz/xpp_hyq.rviz
@@ -101,7 +101,7 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-      Name: Monoped [thvhauwe]
+      Name: Monoped
       Robot Description: /monoped_rviz_urdf_robot_description
       TF Prefix: 
       Update Interval: 0

--- a/robots/xpp_hyq/rviz/xpp_hyq.rviz
+++ b/robots/xpp_hyq/rviz/xpp_hyq.rviz
@@ -101,9 +101,9 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
-      Name: Monoped
+      Name: Monoped [thvhauwe]
       Robot Description: /monoped_rviz_urdf_robot_description
-      TF Prefix: monoped
+      TF Prefix: 
       Update Interval: 0
       Value: false
       Visual Enabled: true
@@ -119,7 +119,7 @@ Visualization Manager:
         Link Tree Style: Links in Alphabetic Order
       Name: Biped
       Robot Description: /biped_rviz_urdf_robot_description
-      TF Prefix: biped
+      TF Prefix: 
       Update Interval: 0
       Value: false
       Visual Enabled: true
@@ -221,7 +221,7 @@ Visualization Manager:
           Value: true
       Name: Hyq
       Robot Description: /hyq_rviz_urdf_robot_description
-      TF Prefix: hyq_des
+      TF Prefix: 
       Update Interval: 0
       Value: true
       Visual Enabled: true
@@ -237,7 +237,7 @@ Visualization Manager:
         Link Tree Style: Links in Alphabetic Order
       Name: ANYmal (proprietary)
       Robot Description: /anymal_rviz_urdf_robot_description
-      TF Prefix: anymal_des
+      TF Prefix: 
       Update Interval: 0
       Value: false
       Visual Enabled: true

--- a/robots/xpp_hyq/src/exe/urdf_visualizer_hyq1.cc
+++ b/robots/xpp_hyq/src/exe/urdf_visualizer_hyq1.cc
@@ -54,8 +54,7 @@ int main(int argc, char *argv[])
   joint_names.at(KFE) = "kfe_joint";
 
   std::string urdf = "monoped_rviz_urdf_robot_description";
-  UrdfVisualizer node_des(urdf, joint_names, "base", "world",
-			  joint_desired_mono, "monoped");
+  UrdfVisualizer node_des(urdf, joint_names, "base", "world", joint_desired_mono);
 
   ::ros::spin();
 

--- a/robots/xpp_hyq/src/exe/urdf_visualizer_hyq2.cc
+++ b/robots/xpp_hyq/src/exe/urdf_visualizer_hyq2.cc
@@ -62,8 +62,7 @@ int main(int argc, char *argv[])
   joint_names.at(n_j*R + KFE) = "R_kfe_joint";
 
   std::string urdf = "biped_rviz_urdf_robot_description";
-  UrdfVisualizer node(urdf, joint_names, "base", "world",
-		      joint_desired_biped, "biped");
+  UrdfVisualizer node(urdf, joint_names, "base", "world", joint_desired_biped);
 
   ::ros::spin();
 

--- a/robots/xpp_hyq/src/exe/urdf_visualizer_hyq4.cc
+++ b/robots/xpp_hyq/src/exe/urdf_visualizer_hyq4.cc
@@ -74,8 +74,7 @@ int main(int argc, char *argv[])
   joint_names.at(n_j*RH + KFE) = "rh_kfe_joint";
 
   std::string urdf = "hyq_rviz_urdf_robot_description";
-  UrdfVisualizer hyq_desired(urdf, joint_names, "base", "world",
-			     joint_desired_hyq, "hyq_des");
+  UrdfVisualizer hyq_desired(urdf, joint_names, "base", "world", joint_desired_hyq);
 
   ::ros::spin();
 

--- a/robots/xpp_quadrotor/src/exe/urdf_visualizer_quadrotor.cc
+++ b/robots/xpp_quadrotor/src/exe/urdf_visualizer_quadrotor.cc
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
 
   // publish base state to RVIZ
   std::string urdf = "quadrotor_rviz_urdf_robot_description";
-  UrdfVisualizer node_des(urdf, {}, "base", "world", joint_quadrotor, "quadrotor");
+  UrdfVisualizer node_des(urdf, {}, "base", "world", joint_quadrotor);
 
   ::ros::spin();
 

--- a/xpp_examples/rviz/xpp_monoped.rviz
+++ b/xpp_examples/rviz/xpp_monoped.rviz
@@ -121,7 +121,7 @@ Visualization Manager:
           Value: true
       Name: Monoped
       Robot Description: /monoped_rviz_urdf_robot_description
-      TF Prefix: monoped
+      TF Prefix: 
       Update Interval: 0
       Value: true
       Visual Enabled: true

--- a/xpp_vis/include/xpp_vis/urdf_visualizer.h
+++ b/xpp_vis/include/xpp_vis/urdf_visualizer.h
@@ -72,15 +72,12 @@ public:
    * @param rviz_fixed_frame  The Fixed Frame name specified in RVIZ.
    * @param state_topic  The topic of the xpp_msgs::RobotStateJoint ROS message
    *        to subscribe to.
-   * @param tf_prefix  In case multiple URDFS are loaded, each can be given a
-   *        unique tf_prefix in RIVZ to visualize different states simultaneously.
    */
   UrdfVisualizer(const std::string& urdf_name,
                  const std::vector<URDFName>& joint_names_in_urdf,
                  const URDFName& base_link_in_urdf,
                  const std::string& rviz_fixed_frame,
-                 const std::string& state_topic,
-                 const std::string& tf_prefix = "");
+                 const std::string& state_topic);
   virtual ~UrdfVisualizer() = default;
 
 private:
@@ -99,7 +96,6 @@ private:
 
   std::string state_msg_name_;
   std::string rviz_fixed_frame_;
-  std::string tf_prefix_;
 };
 
 } // namespace xpp

--- a/xpp_vis/src/urdf_visualizer.cc
+++ b/xpp_vis/src/urdf_visualizer.cc
@@ -35,13 +35,11 @@ UrdfVisualizer::UrdfVisualizer(const std::string& urdf_name,
                                const std::vector<URDFName>& joint_names_in_urdf,
                                const URDFName& base_joint_in_urdf,
                                const std::string& fixed_frame,
-                               const std::string& state_topic,
-                               const std::string& tf_prefix)
+                               const std::string& state_topic)
 {
   joint_names_in_urdf_ = joint_names_in_urdf;
   base_joint_in_urdf_  = base_joint_in_urdf;
   rviz_fixed_frame_   = fixed_frame;
-  tf_prefix_ = tf_prefix;
 
   ::ros::NodeHandle nh;
   state_sub_des_ = nh.subscribe(state_topic, 1, &UrdfVisualizer::StateCallback, this);
@@ -70,8 +68,8 @@ UrdfVisualizer::StateCallback(const xpp_msgs::RobotStateJoint& msg)
   auto W_X_B_message   = GetBaseFromRos(::ros::Time::now(), msg.base.pose);
 
   tf_broadcaster_.sendTransform(W_X_B_message);
-  robot_publisher->publishTransforms(joint_positions, ::ros::Time::now(), tf_prefix_);
-  robot_publisher->publishFixedTransforms(tf_prefix_);
+  robot_publisher->publishTransforms(joint_positions, ::ros::Time::now());
+  robot_publisher->publishFixedTransforms();
 }
 
 UrdfVisualizer::UrdfnameToJointAngle
@@ -93,7 +91,7 @@ UrdfVisualizer::GetBaseFromRos(const ::ros::Time& stamp,
   geometry_msgs::TransformStamped W_X_B_message;
   W_X_B_message.header.stamp    = stamp;
   W_X_B_message.header.frame_id = rviz_fixed_frame_;
-  W_X_B_message.child_frame_id  = tf_prefix_ + "/" + base_joint_in_urdf_;
+  W_X_B_message.child_frame_id  = "/" + base_joint_in_urdf_;
 
   W_X_B_message.transform.translation.x =  msg.position.x;
   W_X_B_message.transform.translation.y =  msg.position.y;


### PR DESCRIPTION
Currently, this package is unavailable to compile under `ros noetic` and thus `Ubuntu 20.04 focal`. Error when building using `catkin build` indicate problems with `tf_prefix`, a relic from `tf` deprecated since `melodic`.

This PR proposes to drop the `tf_prefix` from the `urdf_visualizer.h`, which calls to the `robot_state_publisher.h` header provided by ROS.

It can be seen by comparing these two classes that `publishTransform` method has changed from melodic --> noetic:

http://docs.ros.org/en/melodic/api/robot_state_publisher/html/classrobot__state__publisher_1_1RobotStatePublisher.html
http://docs.ros.org/en/noetic/api/robot_state_publisher/html/classrobot__state__publisher_1_1RobotStatePublisher.html

Edit: related https://github.com/ros/robot_state_publisher/pull/139

Apparantly, the removal of `tf_prefix` is disputed as there is no drop-in replacement functionality in `tf2`. Using this proposed fix will allow to compile under noetic, but break visualization in rviz.
