### PR TITLE
[xpp_examples] Install rviz files

### DIFF
--- a/xpp_examples/CMakeLists.txt
+++ b/xpp_examples/CMakeLists.txt
@@ -53,6 +53,6 @@ install(
 
 # Mark other files for installation
 install(
-  DIRECTORY bags launch
+  DIRECTORY bags launch rviz
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
Thank you for the nice visualization tools. When installing via apt, *.rviz files are not found. This patch is to solve the issue.
```bash
$ dpkg -L ros-melodic-xpp-examples
/.
/opt
/opt/ros
/opt/ros/melodic
/opt/ros/melodic/lib
/opt/ros/melodic/lib/pkgconfig
/opt/ros/melodic/lib/pkgconfig/xpp_examples.pc
/opt/ros/melodic/lib/xpp_examples
/opt/ros/melodic/lib/xpp_examples/monoped_publisher
/opt/ros/melodic/lib/xpp_examples/quadrotor_bag_builder
/opt/ros/melodic/share
/opt/ros/melodic/share/xpp_examples
/opt/ros/melodic/share/xpp_examples/bags
/opt/ros/melodic/share/xpp_examples/bags/README.txt
/opt/ros/melodic/share/xpp_examples/bags/biped.bag
/opt/ros/melodic/share/xpp_examples/bags/gap.bag
/opt/ros/melodic/share/xpp_examples/bags/hyq.bag
/opt/ros/melodic/share/xpp_examples/bags/monoped.bag
/opt/ros/melodic/share/xpp_examples/cmake
/opt/ros/melodic/share/xpp_examples/cmake/xpp_examplesConfig-version.cmake
/opt/ros/melodic/share/xpp_examples/cmake/xpp_examplesConfig.cmake
/opt/ros/melodic/share/xpp_examples/launch
/opt/ros/melodic/share/xpp_examples/launch/biped_bag.launch
/opt/ros/melodic/share/xpp_examples/launch/biped_gap.launch
/opt/ros/melodic/share/xpp_examples/launch/hyq_bag.launch
/opt/ros/melodic/share/xpp_examples/launch/monoped_bag.launch
/opt/ros/melodic/share/xpp_examples/launch/monoped_generate.launch
/opt/ros/melodic/share/xpp_examples/launch/quadrotor_generate.launch
/opt/ros/melodic/share/xpp_examples/package.xml
/usr
/usr/share
/usr/share/doc
/usr/share/doc/ros-melodic-xpp-examples
/usr/share/doc/ros-melodic-xpp-examples/changelog.Debian.gz
```